### PR TITLE
Don't build tests in release.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 3.1
+      if: matrix.configuration == 'Debug'
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.402

--- a/src/TypeNameInterpretation.sln
+++ b/src/TypeNameInterpretation.sln
@@ -20,7 +20,6 @@ Global
 		{8D526B4F-0F2B-40DA-A39C-CFEB504B72EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8D526B4F-0F2B-40DA-A39C-CFEB504B72EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D526B4F-0F2B-40DA-A39C-CFEB504B72EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8D526B4F-0F2B-40DA-A39C-CFEB504B72EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We don't run unit tests in release, so we can reduce wasted effort by not building the test assembly or setting up .Net Core 3.1 for the release builds.