### PR TITLE
Exception serialization.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,6 +128,7 @@ dotnet_diagnostic.SA1101.severity = none
 dotnet_diagnostic.SA1201.severity = none
 dotnet_diagnostic.SA1202.severity = none
 dotnet_diagnostic.SA1204.severity = none
+dotnet_diagnostic.SA1205.severity = none
 dotnet_diagnostic.SA1309.severity = none
 dotnet_diagnostic.SX1309.severity = warning
 dotnet_diagnostic.SX1309S.severity = warning

--- a/src/TypeNameInterpretation/InvalidTypeNameException.NetFramework.cs
+++ b/src/TypeNameInterpretation/InvalidTypeNameException.NetFramework.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Brian Reichle.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
+#if NETFRAMEWORK || NETSTANDARD
+using System;
+using System.Runtime.Serialization;
+
+namespace TypeNameInterpretation
+{
+	[Serializable]
+	partial class InvalidTypeNameException
+	{
+		InvalidTypeNameException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+	}
+}
+#endif

--- a/src/TypeNameInterpretation/InvalidTypeNameException.cs
+++ b/src/TypeNameInterpretation/InvalidTypeNameException.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Brian Reichle.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
 using System;
-using System.Runtime.Serialization;
 
 namespace TypeNameInterpretation
 {
-	[Serializable]
-	public sealed class InvalidTypeNameException : FormatException
+	public sealed partial class InvalidTypeNameException : FormatException
 	{
 		public InvalidTypeNameException()
 		{
@@ -18,11 +16,6 @@ namespace TypeNameInterpretation
 
 		public InvalidTypeNameException(string message, Exception innerException)
 			: base(message, innerException)
-		{
-		}
-
-		InvalidTypeNameException(SerializationInfo info, StreamingContext context)
-			: base(info, context)
 		{
 		}
 	}


### PR DESCRIPTION
This api is considered obsolete in .Net Core but is still needed in .Net Framework. So we will keep it when targeting .Net Framework or .Net Standard and discard it for other targets.