### PR TITLE
Improve performance in LocateStartOfAssembly when running in .NET Core.

### DIFF
--- a/src/TypeNameInterpretation/Delimiters.cs
+++ b/src/TypeNameInterpretation/Delimiters.cs
@@ -8,6 +8,7 @@ static class Delimiters
 {
 #if NET
 	public static SearchValues<char> All { get; } = SearchValues.Create(_allDelimiterChars);
+	public static SearchValues<char> AssemblySearch { get; } = SearchValues.Create(_allDelimiterChars.AsSpan(0, 5));
 	public static SearchValues<char> Quote { get; } = SearchValues.Create(_allDelimiterChars.AsSpan(0, 2));
 #else
 	public static ReadOnlySpan<char> All => _allDelimiterChars.AsSpan();

--- a/src/TypeNameInterpretation/InsParser.cs
+++ b/src/TypeNameInterpretation/InsParser.cs
@@ -323,6 +323,19 @@ static class InsParser
 
 			while (index < _buffer.Length)
 			{
+#if NET
+				// Fast forward to the next meaningful char.
+				// This generally improves the performance in .NET Core but slows down .Net Framework.
+				var i = _buffer.Slice(index).IndexOfAny(Delimiters.AssemblySearch);
+
+				if (i < 0)
+				{
+					return -1;
+				}
+
+				index += i;
+#endif
+
 				var c = _buffer[index];
 
 				if (c == '\\')


### PR DESCRIPTION
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.7840/25H2/2025Update/HudsonValley2)
Intel Core i7-9750H CPU 2.60GHz (Max: 2.59GHz), 1 CPU, 12 logical and 6 physical cores
.NET SDK 10.0.103
  [Host]    : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v3
  .NET 10.0 : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v3
  .NET 8.0  : .NET 8.0.24 (8.0.24, 8.0.2426.7010), X64 RyuJIT x86-64-v3


| Method                   | Job       | Text                 | Mean       | Error     | Ratio |
|------------------------- |---------- |--------------------- |-----------:|----------:|------:|
| NewLocateStartOfAssembly | .NET 10.0 | Foo                  |   4.486 ns | 0.0729 ns |  0.72 |
| OldLocateStartOfAssembly | .NET 10.0 | Foo                  |   6.192 ns | 0.0477 ns |  1.00 |
|                          |           |                      |            |           |       |
| NewLocateStartOfAssembly | .NET 8.0  | Foo                  |   6.612 ns | 0.0444 ns |  0.83 |
| OldLocateStartOfAssembly | .NET 8.0  | Foo                  |   7.952 ns | 0.1845 ns |  1.00 |
|                          |           |                      |            |           |       |
| NewLocateStartOfAssembly | .NET 10.0 | Foo, (...)Quux" [24] |   6.021 ns | 0.0539 ns |  0.75 |
| OldLocateStartOfAssembly | .NET 10.0 | Foo, (...)Quux" [24] |   7.987 ns | 0.0685 ns |  1.00 |
|                          |           |                      |            |           |       |
| NewLocateStartOfAssembly | .NET 8.0  | Foo, (...)Quux" [24] |   8.096 ns | 0.0509 ns |  0.75 |
| OldLocateStartOfAssembly | .NET 8.0  | Foo, (...)Quux" [24] |  10.848 ns | 0.0689 ns |  1.00 |
|                          |           |                      |            |           |       |
| NewLocateStartOfAssembly | .NET 10.0 | Foo`2(...)bly]] [44] |  62.429 ns | 0.4451 ns |  0.69 |
| OldLocateStartOfAssembly | .NET 10.0 | Foo`2(...)bly]] [44] |  90.862 ns | 0.6245 ns |  1.00 |
|                          |           |                      |            |           |       |
| NewLocateStartOfAssembly | .NET 8.0  | Foo`2(...)bly]] [44] |  67.481 ns | 1.3844 ns |  0.63 |
| OldLocateStartOfAssembly | .NET 8.0  | Foo`2(...)bly]] [44] | 106.611 ns | 0.9667 ns |  1.00 |