### PR TITLE
Added a allocation-free fast-path when formatting types.

### DIFF
--- a/src/TypeNameInterpretation.Test/InsFormatterTest.cs
+++ b/src/TypeNameInterpretation.Test/InsFormatterTest.cs
@@ -20,6 +20,13 @@ class InsFormatterTest
 	}
 
 	[Test]
+	public void AvoidAllocationsOnSimpleNamedTypes()
+	{
+		var name = "Foo";
+		Assert.That(Format(NamedType(name)), Is.SameAs(name));
+	}
+
+	[Test]
 	public void AvoidAllocationsOnSimpleAssemblyNames()
 	{
 		var name = "Foo";

--- a/src/TypeNameInterpretation/InsFormatter.cs
+++ b/src/TypeNameInterpretation/InsFormatter.cs
@@ -50,6 +50,12 @@ public static class InsFormatter
 	public static string Format(InsType type)
 	{
 		ArgumentNullException.ThrowIfNull(type);
+
+		if (type.TryFastFormat(out var result))
+		{
+			return result;
+		}
+
 		return Write(BuilderPool.Rent(), type).ToStringAndReturn();
 	}
 
@@ -63,9 +69,9 @@ public static class InsFormatter
 	{
 		ArgumentNullException.ThrowIfNull(assembly);
 
-		if (assembly.Qualifications.Length == 0 && !assembly.Name.AsSpan().ContainsAny(Delimiters.All))
+		if (assembly.TryFastFormat(out var result))
 		{
-			return assembly.Name;
+			return result;
 		}
 
 		return Write(BuilderPool.Rent(), assembly).ToStringAndReturn();

--- a/src/TypeNameInterpretation/Tree/InsAssembly.cs
+++ b/src/TypeNameInterpretation/Tree/InsAssembly.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Brian Reichle.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace TypeNameInterpretation;
 
@@ -34,4 +35,16 @@ public sealed class InsAssembly
 	/// </summary>
 	/// <returns>A non-null formatted assembly reference string.</returns>
 	public override string ToString() => InsFormatter.Format(this);
+
+	internal bool TryFastFormat([NotNullWhen(true)] out string? value)
+	{
+		if (Qualifications.Length == 0 && !Name.AsSpan().ContainsAny(Delimiters.All))
+		{
+			value = Name;
+			return true;
+		}
+
+		value = null;
+		return false;
+	}
 }

--- a/src/TypeNameInterpretation/Tree/InsNamedType.cs
+++ b/src/TypeNameInterpretation/Tree/InsNamedType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Brian Reichle.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace TypeNameInterpretation;
 
@@ -50,5 +51,19 @@ public sealed class InsNamedType : InsType
 	{
 		ArgumentNullException.ThrowIfNull(visitor);
 		return visitor.VisitNamed(this, argument);
+	}
+
+	internal override bool TryFastFormat([NotNullWhen(true)] out string? value)
+	{
+		if (Assembly == null && DeclaringType == null && !Name.AsSpan().ContainsAny(Delimiters.All))
+		{
+			value = Name;
+			return true;
+		}
+		else
+		{
+			value = null;
+			return false;
+		}
 	}
 }

--- a/src/TypeNameInterpretation/Tree/InsType.cs
+++ b/src/TypeNameInterpretation/Tree/InsType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Brian Reichle.  All Rights Reserved.  Licensed under the MIT License.  See LICENSE in the project root for license information.
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace TypeNameInterpretation;
 
@@ -28,7 +29,7 @@ public abstract class InsType
 	/// Returns the canonical string representation of this type.
 	/// </summary>
 	/// <returns>A non-null formatted type name string.</returns>
-	public override string ToString() => InsFormatter.Format(this);
+	public sealed override string ToString() => InsFormatter.Format(this);
 
 	/// <summary>
 	/// Accepts a visitor to perform operations on this type node.
@@ -40,4 +41,10 @@ public abstract class InsType
 	/// <returns>The result returned by the visitor.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="visitor"/> is <see langword="null"/>.</exception>
 	public abstract TReturn Apply<TArgument, TReturn>(IInsTypeVisitor<TArgument, TReturn> visitor, TArgument argument);
+
+	internal virtual bool TryFastFormat([NotNullWhen(true)] out string? value)
+	{
+		value = null;
+		return false;
+	}
 }


### PR DESCRIPTION
Kicks in for `InsNamedType` where we know the result will be the same as simply returning `Name`.