### PR TITLE
Add test case for trailing backslash in type parsing

### DIFF
--- a/src/TypeNameInterpretation.Test/InsParserTest.cs
+++ b/src/TypeNameInterpretation.Test/InsParserTest.cs
@@ -362,6 +362,7 @@ class InsParserTest
 	[TestCase("Foo&[]", ExpectedResult = "Unexpected char at position 4.")]
 	[TestCase("Foo, Bar,", ExpectedResult = "Unexpected end of format.")]
 	[TestCase("Foo[", ExpectedResult = "Unexpected end of format.")]
+	[TestCase("Foo\\", ExpectedResult = "Unexpected end of format.")]
 	public string? Type_Invalid(string typeName)
 	{
 		try


### PR DESCRIPTION
- Extend `InsParserTest.Type_Invalid` with a `[TestCase("Foo\\", ExpectedResult = "Unexpected end of format.")]`.
- The new test verifies that a type name ending in a backslash is handled correctly and does not cause an out‑of‑bounds read in `InsParser.LocateStartOfAssembly`.