### PR TITLE
Attempt to use existing constants when parsing qualification names.

### DIFF
--- a/src/TypeNameInterpretation.Test/InsParserTest.cs
+++ b/src/TypeNameInterpretation.Test/InsParserTest.cs
@@ -23,6 +23,7 @@ class InsParserTest
 	[TestCase("Foo, Bar=Baz, Culture=neutral", "Bar|Baz", "Culture|neutral")]
 	[TestCase("Foo, Bar=Baz", "Bar|Baz")]
 	[TestCase("Foo, \"Bar\"=\"Baz\"", "Bar|Baz")]
+	[TestCase("Foo, \"B\\\"ar\"=\"Baz\"", "B\"ar|Baz")]
 	[TestCase("Foo, Bar=Baz\\,", "Bar|Baz,")]
 	[TestCase("Foo, Bar=\"Baz,\"", "Bar|Baz,")]
 	[TestCase("Foo, Bar=Ba\\\"z", "Bar|Ba\"z")]
@@ -355,6 +356,28 @@ class InsParserTest
 
 		// Ensure we can correctly locate the start of the assembly dispite complex syntax along the way.
 		Assert.That(TreeRenderer.Format(InsTypeFactory.ParseTypeName("Baz[[Foo.Bar[,], FooBar, Culture=\"neu\\\"tr]al\", Frob=bar\\]x, Version=3.14]], Quux")), Is.EqualTo(expected));
+	}
+
+	[Test]
+	public void QualificationKeyReuse()
+	{
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(GetQualificationName("Foo, Version=1.0"), Is.SameAs(WellKnownQualificationNames.Version));
+			Assert.That(GetQualificationName("Foo, PublicKey=abcdef"), Is.SameAs(WellKnownQualificationNames.PublicKey));
+			Assert.That(GetQualificationName("Foo, PublicKeyToken=abcdef"), Is.SameAs(WellKnownQualificationNames.PublicKeyToken));
+			Assert.That(GetQualificationName("Foo, Culture=neutral"), Is.SameAs(WellKnownQualificationNames.Culture));
+			Assert.That(GetQualificationName("Foo, ProcessorArchitecture=neutral"), Is.SameAs(WellKnownQualificationNames.ProcessorArchitecture));
+
+			Assert.That(GetQualificationName("Foo, \"Version\"=1.0"), Is.SameAs(WellKnownQualificationNames.Version));
+		}
+
+		static string GetQualificationName(string assemblyName)
+		{
+			var assembly = InsTypeFactory.ParseAssemblyName(assemblyName);
+			Assert.That(assembly.Qualifications, Has.Length.EqualTo(1));
+			return assembly.Qualifications[0].Name;
+		}
 	}
 
 	[TestCase("Foo]", ExpectedResult = "Unexpected char at position 3.")]

--- a/src/TypeNameInterpretation/InsParser.cs
+++ b/src/TypeNameInterpretation/InsParser.cs
@@ -216,11 +216,65 @@ static class InsParser
 		{
 			AssertNotEOF(index);
 
-			var name = ParseQuoteableIdentifier(ref index);
+			var name = ParseQualificationKey(ref index);
 			ReadChar(ref index, '=');
 			var value = ParseQuoteableIdentifier(ref index);
 
 			return new InsAssemblyQualification(name, value);
+		}
+
+		string ParseQualificationKey(ref int index)
+		{
+			if (TrySliceIdentifier(ref index, out var identifierSpan))
+			{
+				return identifierSpan switch
+				{
+					// At the time of writing, the compiler does not optimise this. Instead it generates
+					// a series of sequence equality checks. So we sort them by how likely they are to
+					// turn up in a partially qualified assembly name.
+					WellKnownQualificationNames.Version => WellKnownQualificationNames.Version,
+					WellKnownQualificationNames.PublicKeyToken => WellKnownQualificationNames.PublicKeyToken,
+					WellKnownQualificationNames.Culture => WellKnownQualificationNames.Culture,
+					WellKnownQualificationNames.PublicKey => WellKnownQualificationNames.PublicKey,
+					WellKnownQualificationNames.ProcessorArchitecture => WellKnownQualificationNames.ProcessorArchitecture,
+					_ => identifierSpan.ToString(),
+				};
+			}
+
+			return ParseQuoteableIdentifier(ref index);
+		}
+
+		// Attempts to parse an identifier and return it as a ReadOnlySpan<> to avoid an allocation.
+		// This only works if the identifier does not escape any characters, if it does then it
+		// returns false and the caller should fallback to using ParseQuoteableIdentifier instead.
+		// The `index` parameter will only be advanced if TrySliceIdentifier returns true, indicating
+		// that it successfully consumed input.
+		bool TrySliceIdentifier(ref int index, out ReadOnlySpan<char> identifier)
+		{
+			var pos = index;
+
+			if (TryReadChar(ref pos, '"'))
+			{
+				if (TrySliceIdentifierCore(_buffer.Slice(pos), Delimiters.Quote, out identifier))
+				{
+					pos += identifier.Length;
+					ReadChar(ref pos, '"');
+					index = pos;
+					return true;
+				}
+			}
+			else
+			{
+				if (TrySliceIdentifierCore(_buffer.Slice(pos), Delimiters.All, out identifier))
+				{
+					pos += identifier.Length;
+					index = pos;
+					return true;
+				}
+			}
+
+			identifier = [];
+			return false;
 		}
 
 		string ParseQuoteableIdentifier(ref int index)
@@ -236,6 +290,39 @@ static class InsParser
 		}
 
 		string ParseIdentifier(ref int index) => ParseIdentifierCore(ref index, Delimiters.All);
+
+#if NET
+		static bool TrySliceIdentifierCore(ReadOnlySpan<char> source, SearchValues<char> delimiters, out ReadOnlySpan<char> identifier)
+#else
+		static bool TrySliceIdentifierCore(ReadOnlySpan<char> source, ReadOnlySpan<char> delimiters, out ReadOnlySpan<char> identifier)
+#endif
+		{
+			var index = 0;
+
+			while (true)
+			{
+				var i = source.Slice(index).IndexOfAny(delimiters);
+
+				if (i < 0)
+				{
+					index = source.Length;
+					break;
+				}
+
+				index += i;
+
+				if (source[index] != '\\')
+				{
+					break;
+				}
+
+				identifier = [];
+				return false;
+			}
+
+			identifier = source.Slice(0, index);
+			return true;
+		}
 
 #if NET
 		string ParseIdentifierCore(ref int index, SearchValues<char> delimiters)


### PR DESCRIPTION
Qualification names will almost certainly be one of the 5 known. So we should use the existing strings rather than allocating a new one each time.