### PR TITLE
Make ToHexString a bit faster.

### DIFF
--- a/src/TypeNameInterpretation/FrameworkExtensions/ConvertShims.cs
+++ b/src/TypeNameInterpretation/FrameworkExtensions/ConvertShims.cs
@@ -24,10 +24,30 @@ static class ConvertShims
 			}
 
 			var charCount = blob.Length * 2;
-			var sharedArray = ArrayPool<char>.Shared.Rent(charCount);
-			EncodeCore(ref MemoryMarshal.GetReference(blob), ref sharedArray[0], blob.Length);
-			ArrayPool<char>.Shared.Return(sharedArray);
-			return new string(sharedArray, 0, charCount);
+
+			if (blob.Length <= 8)
+			{
+				// For short sequences, the overhead of using ArrayPool<> will wipe away all the gains.
+#if NETFRAMEWORK || NETSTANDARD2_0
+				unsafe
+				{
+					var ptr = stackalloc char[charCount];
+					EncodeCore(ref MemoryMarshal.GetReference(blob), ref Unsafe.AsRef<char>(ptr), blob.Length);
+					return new string(ptr, 0, charCount);
+				}
+#else
+				Span<char> buffer = stackalloc char[charCount];
+				EncodeCore(ref MemoryMarshal.GetReference(blob), ref MemoryMarshal.GetReference(buffer), blob.Length);
+				return buffer.ToString();
+#endif
+			}
+			else
+			{
+				var sharedArray = ArrayPool<char>.Shared.Rent(charCount);
+				EncodeCore(ref MemoryMarshal.GetReference(blob), ref sharedArray[0], blob.Length);
+				ArrayPool<char>.Shared.Return(sharedArray);
+				return new string(sharedArray, 0, charCount);
+			}
 		}
 #endif
 

--- a/src/TypeNameInterpretation/FrameworkExtensions/ConvertShims.cs
+++ b/src/TypeNameInterpretation/FrameworkExtensions/ConvertShims.cs
@@ -23,19 +23,9 @@ static class ConvertShims
 				return string.Empty;
 			}
 
-			var charLookup = "0123456789ABCDEF";
 			var charCount = blob.Length * 2;
 			var sharedArray = ArrayPool<char>.Shared.Rent(charCount);
-
-			for (var i = 0; i < blob.Length; i++)
-			{
-				var b = blob[i];
-				var destIndex = i * 2;
-
-				sharedArray[destIndex] = charLookup[b >> 4];
-				sharedArray[destIndex + 1] = charLookup[b & 0xF];
-			}
-
+			EncodeCore(ref MemoryMarshal.GetReference(blob), ref sharedArray[0], blob.Length);
 			ArrayPool<char>.Shared.Return(sharedArray);
 			return new string(sharedArray, 0, charCount);
 		}
@@ -113,5 +103,23 @@ static class ConvertShims
 
 		return true;
 	}
+
+#if !NET
+	static void EncodeCore(ref byte source, ref char target, int sourceLength)
+	{
+		var charLookup = "0123456789ABCDEF";
+
+		while (sourceLength-- > 0)
+		{
+			var b = source;
+			source = ref Unsafe.Add(ref source, 1);
+
+			target = charLookup[b >> 4];
+			target = ref Unsafe.Add(ref target, 1);
+			target = charLookup[b & 0xF];
+			target = ref Unsafe.Add(ref target, 1);
+		}
+	}
+#endif
 }
 #endif

--- a/src/TypeNameInterpretation/FrameworkExtensions/ConvertShims.cs
+++ b/src/TypeNameInterpretation/FrameworkExtensions/ConvertShims.cs
@@ -23,19 +23,21 @@ static class ConvertShims
 				return string.Empty;
 			}
 
-			var builder = BuilderPool.Rent(blob.Length * 2);
 			var charLookup = "0123456789ABCDEF";
+			var charCount = blob.Length * 2;
+			var sharedArray = ArrayPool<char>.Shared.Rent(charCount);
 
 			for (var i = 0; i < blob.Length; i++)
 			{
 				var b = blob[i];
+				var destIndex = i * 2;
 
-				builder
-					.Append(charLookup[b >> 4])
-					.Append(charLookup[b & 0xF]);
+				sharedArray[destIndex] = charLookup[b >> 4];
+				sharedArray[destIndex + 1] = charLookup[b & 0xF];
 			}
 
-			return builder.ToStringAndReturn();
+			ArrayPool<char>.Shared.Return(sharedArray);
+			return new string(sharedArray, 0, charCount);
 		}
 #endif
 


### PR DESCRIPTION
```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8875/25H2/2025Update/HudsonValley2)
Intel Core i7-9750H CPU 2.60GHz (Max: 2.59GHz), 1 CPU, 12 logical and 6 physical cores
  [Host]             : .NET Framework 4.8.1 (4.8.9337.0), X64 RyuJIT VectorSize=256
  .NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9337.0), X64 RyuJIT VectorSize=256

Job=.NET Framework 4.8  Runtime=.NET Framework 4.8
```

| Method         | Length | Mean      | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------------- |------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| ToHexString    | 8      |  42.38 ns | 0.337 ns | 0.263 ns |  0.55 |    0.01 | 0.0102 |      64 B |        1.00 |
| OldToHexString | 8      |  76.49 ns | 1.469 ns | 1.302 ns |  1.00 |    0.02 | 0.0101 |      64 B |        1.00 |
|                |        |           |          |          |       |         |        |           |             |
| ToHexString    | 40     | 127.74 ns | 2.165 ns | 2.223 ns |  0.51 |    0.01 | 0.0305 |     193 B |        1.00 |
| OldToHexString | 40     | 250.88 ns | 3.870 ns | 4.141 ns |  1.00 |    0.02 | 0.0305 |     193 B |        1.00 |
